### PR TITLE
updated dashboard to load assigned tickets to user

### DIFF
--- a/client/dashboard/src/components/dashboard/AppAdmin.js
+++ b/client/dashboard/src/components/dashboard/AppAdmin.js
@@ -72,7 +72,6 @@ class AppAdmin extends Component {
 		$('body').css('background', 'none');
 		$('#admin-portal').hide();
 		$('#loader').show();
-
 		//validates that user is logged in, then fetches their inital data: user, admins, organization
 		$.get('/api/validateAuth', (user)=>{
 			if (user) {
@@ -84,7 +83,7 @@ class AppAdmin extends Component {
 				})
 			}
 			else window.location.href = '/login';
-		})
+		});
 	}
 	componentWillUnmount(){
 		window.removeEventListener('resize', this.handleResize);

--- a/client/dashboard/src/components/dashboard/pages/Dashboard.js
+++ b/client/dashboard/src/components/dashboard/pages/Dashboard.js
@@ -8,12 +8,13 @@ class Dashboard extends Component {
 		super();
 		this.state = {
 			loading: <div id="loader-sm" />,
+			details: [],
 			tickets: []
 		}
 	}
-	componentDidMount(){
+	componentDidMount() {
 		if (this.props.user) {
-			let data = {status: "New", assignedto: this.props.user.username};
+			let data = { status: "New", assigned: true };
 			$.post('/api/querytickets', data, (tickets) => {
 				if (tickets.length) {
 					this.setState({tickets: tickets, loading: <div />})
@@ -23,7 +24,19 @@ class Dashboard extends Component {
 			});
 		};
 	}
+	setDetail = (id) => {
+		let details = this.state.details.concat(id);
+		let unique = details.reduce((uniq, item) => {
+			return (uniq.indexOf(item) == -1) ? uniq.concat(item) : uniq;
+		}, []);
+		this.setState({ details: unique });
+	}
+	closeDetails = (id) => {
+		let details = this.state.details.filter(item => item !== id);
+		this.setState({ details });
+	}
 	render() {
+		let { details } = this.state;
 		return (
 			<div>
 				<div className="card" id="dash-task">
@@ -32,7 +45,17 @@ class Dashboard extends Component {
 				<div className="card">
 					{this.state.loading}
 					{this.state.tickets.map((ticket)=>{
-						return <TicketTemplate ticket={ticket} admins={this.props.admins} key={ticket._id}/>
+						let showDetails = null;
+						if (details.indexOf(ticket._id) !== -1) showDetails = true;
+						return (
+							<TicketTemplate
+								showDetails={showDetails}
+								setDetail={this.setDetail}
+								closeDetails={this.closeDetails}
+								ticket={ticket}
+								admins={this.props.admins}
+								key={ticket._id} />
+						)
 					})}
 				</div>
 			</div>

--- a/routes.js
+++ b/routes.js
@@ -124,8 +124,6 @@ router.post('/api/createadmin', function(req, res){
 });
 
 
-
-
 //READ: User checks the status on their tickets
 router.get('/api/check/:email', function(req, res){
 	console.log(req.params.email + " requested info on their current work orders");
@@ -171,9 +169,12 @@ router.get('/api/initialData', function(req, res){
 //Just make a POST request, with a JSON object of your search params!
 router.post('/api/querytickets', function(req, res){
 	let { organization } = req.user;
-	console.log(req.body);
-	Ticket.find(organization).sort({date: -1}).exec(function(err, tickets) {
+	Ticket.find(organization, function(err, tickets) {
+		let assignee = req.user.username;
 		tickets = tickets.filter(ticket => ticket.status == req.body.status);
+		if (req.body.assigned) {
+			tickets = tickets.filter(ticket => ticket.assignedto === assignee);
+		};
 		if (err) throw err;
 		res.send(tickets);
 	})


### PR DESCRIPTION
I updated the dashboard to load tickets assigned to the user upon login. I changed the way it was requesting `assignedto` because of an issue where this was not working at first, so it now just pulls the user email from `req.user` and filters the tickets based on that. I think it is all working properly now.

Also the server keeps throwing some error whenever you click on dashboard from the home screen if you're not logged in. I'm not sure what's it's from.